### PR TITLE
Add ws:// autocompletion

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,20 +1,3 @@
-const messages = document.getElementById("message-list");
-const inputBox = document.getElementById("input-box");
-const params = new URLSearchParams(window.location.search);
-
-let ip = params.has("ip") ? params.get("ip") : prompt("Please enter the IP address of a server:");
-let name = params.has("name") ? params.get("name") : prompt("Please enter your username:");
-
-if (ip.startsWith("https://") || ip.startsWith("https://")) {
-    const protocol = "wss://";
-} else {
-    const protocol = "ws://";
-}
-
-ip = protocol + ip.slice(ip.indexOf("/") + 1);
-
-const socket = new WebSocket(ip);
-
 function createMessageElement(message) {
     let element = document.createElement("div");
     element.className = "message";
@@ -24,6 +7,22 @@ function createMessageElement(message) {
 
     messages.appendChild(element);
 }
+
+const messages = document.getElementById("message-list");
+const inputBox = document.getElementById("input-box");
+const params = new URLSearchParams(window.location.search);
+
+let ip = params.has("ip") ? params.get("ip") : prompt("Please enter the IP address of a server:");
+let name = params.has("name") ? params.get("name") : prompt("Please enter your username:");
+let protocol = "ws://";
+
+if (ip.startsWith("https://") || ip.startsWith("wss://")) {
+    protocol = "wss://";
+}
+
+ip = protocol + ip.slice(ip.indexOf("/") + 2);
+
+const socket = new WebSocket(ip);
 
 inputBox.addEventListener("keydown", (event) => {
     if (event.key != "Enter") {

--- a/script.js
+++ b/script.js
@@ -1,9 +1,10 @@
 const messages = document.getElementById("message-list");
 const inputBox = document.getElementById("input-box");
-
+const wsorwss = window.location.href.startsWith("https://") ? "wss://" : "ws://"
 const params = new URLSearchParams(window.location.search);
 
 let ip = params.has("ip") ? params.get("ip") : prompt("Please enter the IP address of a server:");
+ip = (ip.startsWith("ws://")||ip.startsWith("wss://")) ? ip : (ip.includes("://") ? wsorwss+ip.split("://")[ip.split("://").length-1] : wsorwss+ip) // fix if IP is not websocket url
 let name = params.has("name") ? params.get("name") : prompt("Please enter your username:");
 
 const socket = new WebSocket(ip);

--- a/script.js
+++ b/script.js
@@ -1,11 +1,17 @@
 const messages = document.getElementById("message-list");
 const inputBox = document.getElementById("input-box");
-const wsorwss = window.location.href.startsWith("https://") ? "wss://" : "ws://"
 const params = new URLSearchParams(window.location.search);
 
 let ip = params.has("ip") ? params.get("ip") : prompt("Please enter the IP address of a server:");
-ip = (ip.startsWith("ws://")||ip.startsWith("wss://")) ? ip : (ip.includes("://") ? wsorwss+ip.split("://")[ip.split("://").length-1] : wsorwss+ip) // fix if IP is not websocket url
 let name = params.has("name") ? params.get("name") : prompt("Please enter your username:");
+
+if (ip.startsWith("https://") || ip.startsWith("https://")) {
+    const protocol = "wss://";
+} else {
+    const protocol = "ws://";
+}
+
+ip = protocol + ip.slice(ip.indexOf("/") + 1);
 
 const socket = new WebSocket(ip);
 


### PR DESCRIPTION
## README.md doesn't necessary specify which protocol to use. This PR updates it, so it should use ws or wss protocol. 
### Tested cases:

`localhost:1000` -> `ws://localhost:1000`
`http(/s)://localhost:1000` -> ws://localhost:1000`

### **If you want to use wss on http server or ws on https server (which will probably result in an error), just add protocol**